### PR TITLE
Use int lock with acquire/release atomics instead of std::lock_guard

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -237,6 +237,8 @@ void OpenMPInternal::initialize(int thread_count) {
 )WARNING" << std::endl;
     }
 
+    m_pool_mutex = 0;
+
     OpenMP::memory_space space;
 
     // Before any other call to OMP query the maximum number of threads

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -74,7 +74,7 @@ class OpenMPInternal {
  public:
   friend class Kokkos::OpenMP;
 
-  std::mutex m_pool_mutex;
+  int m_pool_mutex;
 
   static OpenMPInternal& singleton();
 


### PR DESCRIPTION
Switching out the lock_guard on mutex with a and integer lock using acquire/release atomics removes most of the performance regression in LAMMPS. I believe this is correct semantics. I also tried relaxed atomics. Relaxed atomics on their own don't have any overhead either, but then adding Kokkos::memory_fence() at the beginning and end gets you back to the lock_guard performance. Just having one memory_fence() before the atomic_store, but none at the entry (which I think is also good enough) reduces the performance regression by about half. In the end my guess is that lock_guard is a heavier memory fencing mechanism than what we need here. 